### PR TITLE
Fix header guard

### DIFF
--- a/UnitTest1/ByteBuffer.h
+++ b/UnitTest1/ByteBuffer.h
@@ -5,6 +5,7 @@
 #include <iterator>
 #include <string>
 
+#ifndef BYTEBUFFER_H
 #define BYTEBUFFER_H
 
 class ByteBuffer {
@@ -146,3 +147,4 @@ inline T ByteBuffer::get(size_t idx)
 
     return ans;
 }
+#endif


### PR DESCRIPTION
The header guard in this file was incomplete and would not actually function, additionally `#pragma once` is nonstandard and should be removed but I did not include it here.